### PR TITLE
ops: fixes cicd for localnet merges

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CICD
 on:
   push:
     branches:
-      -localnet
+      - localnet
       - devnet
       - mainnet
   pull_request:


### PR DESCRIPTION
cicd wasn't running for localnet because of a missing space in the yaml